### PR TITLE
Create tenants and common projects

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,16 +1,24 @@
 ThisBuild / dynverSeparator := "-"
 
 lazy val backEnd = project.in(file("."))
-  .aggregate(organization, member)
+  .aggregate(commonTypes, tenant)
 
-lazy val organization = project.in(file("organization"))
-  .configure(C.kalix("improving-app-organization"))
+// Unused projects. Completely remove once organization and member are correctly implemented.
+//lazy val organization = project.in(file("organization"))
+//  .configure(C.kalix("improving-app-organization"))
+//
+//lazy val member = project.in(file("member"))
+//  .configure(C.kalix("improving-app-member"))
+//  .dependsOn(organization).
+//  settings(
+//    libraryDependencies ++= Seq(
+//      "org.typelevel" %% "cats-core" % "2.8.0"
+//    )
+//  )
 
-lazy val member = project.in(file("member"))
-  .configure(C.kalix("improving-app-member"))
-  .dependsOn(organization).
-  settings(
-    libraryDependencies ++= Seq(
-      "org.typelevel" %% "cats-core" % "2.8.0"
-    )
-  )
+//might need to put common types (like memberId...
+lazy val commonTypes = project.in(file("commonTypes"))
+  .configure(C.akkaPersistentEntity("improving-app-common-types"))
+
+lazy val tenant = project.in(file("tenant"))
+  .configure(C.protobufsLib("improving-app-tenant"))

--- a/build.sbt
+++ b/build.sbt
@@ -16,9 +16,9 @@ lazy val backEnd = project.in(file("."))
 //    )
 //  )
 
-// This is for types defined at 'domain' scope and having cross-service applicability only.
+// This is for protobuf types defined at 'domain' scope and having cross-service applicability only.
 lazy val commonTypes = project.in(file("common-types"))
-  .configure(C.akkaPersistentEntity("improving-app-common-types"))
+  .configure(C.protobufsLib("improving-app-common-types"))
 
 lazy val tenant = project.in(file("tenant"))
   .configure(C.akkaPersistentEntity("improving-app-tenant"))

--- a/build.sbt
+++ b/build.sbt
@@ -16,9 +16,9 @@ lazy val backEnd = project.in(file("."))
 //    )
 //  )
 
-//might need to put common types (like memberId...
-lazy val commonTypes = project.in(file("commonTypes"))
+// This is for types defined at 'domain' scope and having cross-service applicability only.
+lazy val commonTypes = project.in(file("common-types"))
   .configure(C.akkaPersistentEntity("improving-app-common-types"))
 
 lazy val tenant = project.in(file("tenant"))
-  .configure(C.protobufsLib("improving-app-tenant"))
+  .configure(C.akkaPersistentEntity("improving-app-tenant"))

--- a/common-types/src/main/protobuf/com/contact/address.proto
+++ b/common-types/src/main/protobuf/com/contact/address.proto
@@ -1,0 +1,23 @@
+syntax = "proto3";
+
+package com.contact;
+
+// Either a USA or Canadian postal code
+message PostalCode {
+  oneof postalCode {
+    // A USA postal code
+    string caPostalCode = 1;
+    // A Canadian postal code
+    string usPostalCode = 2;
+  }
+}
+
+// A generalized north american postal address
+message Address {
+  string line1 = 1;
+  string line2 = 2;
+  string city = 3;
+  string stateProvince = 4;
+  string country = 5;
+  PostalCode postalCode = 6;
+}

--- a/project/Helpers.scala
+++ b/project/Helpers.scala
@@ -5,6 +5,26 @@ import sbt.{Project, Test, Tests, _}
 import sbt.Keys._
 import kalix.sbt.KalixPlugin
 
+/**
+ * Contains the versions needed.
+ */
+object V {
+  lazy val scala = "2.13.8"
+  lazy val akka = "2.7.0"
+  lazy val akkaHttp = "10.5.0"
+  lazy val akkaGrpc = "2.1.3"
+  lazy val akkaManagement = "1.2.0"
+  lazy val akkaProjection = "1.3.1"
+  lazy val akkaPersistenceJdbc = "5.2.1"
+  lazy val postgres = "42.5.4"
+  lazy val postgresSocketFactory = "1.10.0"
+  lazy val pubsub = "1.123.2"
+  lazy val slick = "3.4.1"
+  lazy val cors = "1.1.3"
+  lazy val logback = "1.4.5"
+  lazy val scalatest = "3.2.15"
+}
+
 // C for Configuration functions
 object C {
 
@@ -28,7 +48,7 @@ object C {
         organization := "com.improving",
         organizationHomepage := Some(url("https://improving.app")),
         licenses := Seq(("Apache 2", url("https://www.apache.org/licenses/LICENSE-2.0"))),
-        scalaVersion := "2.13.8",
+        scalaVersion := V.scala,
         scalacOptions := scala3Options,
         Compile / scalacOptions ++= scala3Options,
         Compile / javacOptions ++= javaOptions,
@@ -57,4 +77,77 @@ object C {
       )
   }
 
+  def akkaPersistentEntity(artifactName: String)(project: Project): Project = {
+    project.enablePlugins(JavaAppPackaging, DockerPlugin)
+      .settings(
+        name := artifactName,
+        organization := "com.improving",
+        organizationHomepage := Some(url("https://improving.app")),
+        licenses := Seq(("Apache 2", url("https://www.apache.org/licenses/LICENSE-2.0"))),
+        scalaVersion := V.scala,
+        scalacOptions := scala3Options,
+        Compile / scalacOptions ++= scala3Options,
+        Compile / javacOptions ++= javaOptions,
+        Test / parallelExecution := false,
+        Test / testOptions += Tests.Argument("-oDF"),
+        Test / logBuffered := false,
+        run / fork := false,
+        Global / cancelable := false, // ctrl-c
+        libraryDependencies ++= Seq(
+          "com.typesafe.akka" %% "akka-http" % V.akkaHttp,
+          "com.typesafe.akka" %% "akka-http2-support" % V.akkaHttp ,
+          "com.typesafe.akka" %% "akka-http-spray-json" % V.akkaHttp,
+          "com.typesafe.akka" %% "akka-actor-typed" % V.akka,
+          "com.typesafe.akka" %% "akka-persistence-typed" % V.akka,
+          "com.lightbend.akka" %% "akka-persistence-jdbc" % V.akkaPersistenceJdbc,
+          "org.postgresql" % "postgresql" % V.postgres,
+          "com.google.cloud.sql" % "postgres-socket-factory" % V.postgresSocketFactory,
+          "com.google.cloud" % "google-cloud-pubsub" % V.pubsub,
+          "com.typesafe.akka" %% "akka-cluster-sharding-typed" % V.akka,
+          "com.typesafe.akka" %% "akka-persistence-query" % V.akka,
+          "com.lightbend.akka" %% "akka-projection-eventsourced" % V.akkaProjection,
+          "com.lightbend.akka" %% "akka-projection-slick" % V.akkaProjection,
+          "com.lightbend.akka" %% "akka-projection-jdbc" % V.akkaProjection,
+          "com.typesafe.akka" %% "akka-stream" % V.akka,
+          "com.typesafe.akka" %% "akka-discovery" % V.akka,
+          "com.lightbend.akka.discovery" %% "akka-discovery-kubernetes-api" % V.akkaManagement,
+          "com.lightbend.akka.management" %% "akka-management-cluster-bootstrap" % V.akkaManagement,
+          "com.typesafe.akka" %% "akka-serialization-jackson" % V.akka,
+          "com.typesafe.akka" %% "akka-slf4j" % V.akka,
+          "com.typesafe.slick" %% "slick" % V.slick,
+          "com.typesafe.slick" %% "slick-hikaricp" % V.slick,
+          "ch.qos.logback" % "logback-classic" % V.logback,
+          "com.typesafe.akka" %% "akka-actor-testkit-typed" % V.akka % Test,
+          "com.typesafe.akka" %% "akka-stream-testkit" % V.akka % Test,
+          "org.scalatest" %% "scalatest" % V.scalatest % Test),
+        dockerBaseImage := "docker.io/library/adoptopenjdk:11-jre-hotspot",
+        dockerUsername := sys.props.get("docker.username"),
+        dockerRepository := sys.props.get("docker.registry"),
+        dockerUpdateLatest := true,
+        dockerBuildCommand := {
+          if (sys.props("os.arch") != "amd64") {
+            // use buildx with platform to build supported amd64 images on other CPU architectures
+            // this may require that you have first run 'docker buildx create' to set docker buildx up
+            dockerExecCommand.value ++ Seq("buildx", "build", "--platform=linux/amd64", "--load") ++ dockerBuildOptions.value :+ "."
+          } else dockerBuildCommand.value
+        }
+      )
+  }
+
+  def protobufsLib(artifactName: String)(project: Project): Project = {
+    project.enablePlugins(JavaAppPackaging)
+      .settings(
+        name := artifactName,
+        organization := "com.improving",
+        organizationHomepage := Some(url("https://improving.app")),
+        licenses := Seq(("Apache 2", url("https://www.apache.org/licenses/LICENSE-2.0"))),
+        scalaVersion := V.scala,
+        scalacOptions := scala3Options,
+        Compile / scalacOptions ++= scala3Options,
+        Test / logBuffered := false,
+        run / fork := false,
+        Global / cancelable := false, // ctrl-c
+        libraryDependencies ++= Seq("org.scalatest" %% "scalatest" % V.scalatest % Test),
+      )
+  }
 }

--- a/project/Helpers.scala
+++ b/project/Helpers.scala
@@ -94,7 +94,6 @@ object C {
         run / fork := false,
         Global / cancelable := false, // ctrl-c
         libraryDependencies ++= Seq(
-          "com.typesafe.akka" %% "akka-actor" % V.akka,
           "com.typesafe.akka" %% "akka-actor-typed" % V.akka,
           "com.typesafe.akka" %% "akka-actor-testkit-typed" % V.akka % Test,
           "com.typesafe.akka" %% "akka-cluster-tools" % V.akka,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,3 +2,10 @@ addSbtPlugin("io.kalix" % "sbt-kalix" % System.getProperty("kalix-sdk.version", 
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.8.1")
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.1.1")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.2")
+addSbtPlugin("com.lightbend.akka.grpc" % "sbt-akka-grpc" % "2.2.1")
+addSbtPlugin("com.thesamet" % "sbt-protoc" % "1.0.3")
+
+libraryDependencies ++= Seq(
+  "com.thesamet.scalapb" %% "compilerplugin"           % "0.11.13",
+  "com.thesamet.scalapb" %% "scalapb-validate-codegen" % "0.3.4"
+)


### PR DESCRIPTION
Primary Reviewer: @reid-spencer 

### Issue:
- Coming back to the back-end project, we are essentially starting from scratch as all other projects present in this repository are implemented with Kalix or have just gone stale
- We need to create the common folder to hold some common types (ie. memberId, eventId, etc.)
- We need to create the tenant folder to hold the tenant entity

### Changes:
- Commented out unused projects in the build.sbt that is implemented through Kalix
- Add functions in the Helpers for helping create the tenant and common project

### Testing:
- sbt compile should compile