### PR TITLE
IA-140: Refactor Common Test Code

### DIFF
--- a/common-types/src/main/scala/com/improving/app/common/service/ServiceMain.scala
+++ b/common-types/src/main/scala/com/improving/app/common/service/ServiceMain.scala
@@ -1,0 +1,58 @@
+package com.improving.app.common.service
+
+import akka.actor.typed.ActorSystem
+import akka.actor.typed.scaladsl.Behaviors
+import akka.http.scaladsl.Http
+import akka.http.scaladsl.model.{HttpRequest, HttpResponse}
+import com.typesafe.config.ConfigFactory
+import com.typesafe.scalalogging.StrictLogging
+import org.scalatest.time.SpanSugar.convertIntToGrainOfTime
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.{Failure, Success}
+
+/**
+ * This trait is extended by the gRPC services. This file represents the typical pattern for a gRPC server
+ * and the parts that only vary across projects is the projectName, port, and ServiceHandler/ServiceImpl to use.
+ */
+trait ServiceMain extends App with StrictLogging{
+  // projectName is the name of the service, usually in the format of 'improving-app-SOME-SERVICE'
+  protected val projectName: String
+
+  // port is where the server should be listening to
+  protected val port: Int
+
+  // The service to bind to
+  protected def service(system: ActorSystem[Nothing]): HttpRequest => Future[HttpResponse]
+
+  /**
+   * The function to run for Main
+   */
+  protected def run(): Unit = {
+
+    val conf = ConfigFactory
+      .load("application.conf")
+      .withFallback(ConfigFactory.defaultApplication())
+    implicit val system = ActorSystem[Nothing](Behaviors.empty, projectName, conf)
+
+    // ActorSystem threads will keep the app alive until `system.terminate()` is called
+
+    // Akka boot up code
+    implicit val ec: ExecutionContext = system.executionContext
+
+    val bound: Future[Http.ServerBinding] = Http(system)
+      .newServerAt(interface = "0.0.0.0", port = port)
+      //      .enableHttps(serverHttpContext)
+      .bind(service(system))
+      .map(_.addToCoordinatedShutdown(hardTerminationDeadline = 30.seconds))
+
+    bound.onComplete {
+      case Success(binding) =>
+        val address = binding.localAddress
+        println(s"$projectName gRPC server bound to ${address.getHostString}:${address.getPort}")
+      case Failure(ex) =>
+        println(s"Failed to bind gRPC endpoint for $projectName, terminating system: ${ex.getMessage}")
+        system.terminate()
+    }
+  }
+}

--- a/common-types/src/main/scala/com/improving/app/common/test/ServiceTestContainerSpec.scala
+++ b/common-types/src/main/scala/com/improving/app/common/test/ServiceTestContainerSpec.scala
@@ -1,0 +1,64 @@
+package com.improving.app.common.test
+
+import akka.actor.ActorSystem
+import com.dimafeng.testcontainers.{DockerComposeContainer, ExposedService}
+import com.dimafeng.testcontainers.scalatest.TestContainerForAll
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.time.{Millis, Minutes, Span}
+import org.testcontainers.containers.wait.strategy.Wait
+
+import java.io.File
+
+/**
+ * ServiceTestContainerSpec class is the typical pattern for testing services that are gRPC services in a
+ * Docker container. The service in question should be present in the docker-compose.yml.
+ *
+ * When running the test cases that extends this class, it is assumed that the user already has a docker container for
+ * persistence (Scylla-DB) and has already run the command 'sbt clean compile && sbt docker:stage && sbt docker:publishLocal'
+ * @param exposedPort The exposedPort is an Integer that should match the port exposed in docker-compose.yml
+ * @param serviceName The serviceName is a String that should match the port exposed in docker-compose.yml
+ */
+class ServiceTestContainerSpec(exposedPort: Integer, serviceName: String)
+  extends AnyFlatSpec
+    with TestContainerForAll
+    with Matchers
+    with ScalaFutures {
+
+  // Implicits for running and testing functions of the gRPC server
+  implicit override val patienceConfig: PatienceConfig =
+    PatienceConfig(timeout = Span(3, Minutes), interval = Span(10, Millis))
+  implicit protected val system: ActorSystem = ActorSystem("testActor")
+
+  // The definition of the container to use. The docker-compose file is used to start the service and waits for the appropriate message
+  override val containerDef = DockerComposeContainer.Def(
+    new File("./docker-compose.yml"),
+    tailChildContainers = true,
+    exposedServices = Seq(
+      ExposedService(serviceName, exposedPort, Wait.forLogMessage(s".*gRPC server bound to 0.0.0.0:$exposedPort*.", 1))
+    )
+  )
+
+  /**
+   * Gets the appropriate host and port of the container. A feature of TestContainer is that the actual host and port used may be
+   * different from what you defined in the docker-compose file. This means that the host and port has to be resolved,
+   * and only then can you use the client.
+   * @param containers
+   * @return
+   */
+  protected def getContainerHostPort(containers: Containers): (String, Integer) = {
+    val host = containers.container.getServiceHost(serviceName, exposedPort)
+    val port = containers.container.getServicePort(serviceName, exposedPort)
+
+    (host, port)
+  }
+
+  /**
+   * Trivial test case to see if the service is running.
+   * @param a
+   */
+  protected def validateExposedPort(a: Containers): Unit = {
+    assert(a.container.getServicePort(serviceName, exposedPort) > 0)
+  }
+}

--- a/member/src/it/scala/MemberServerSpec.scala
+++ b/member/src/it/scala/MemberServerSpec.scala
@@ -1,36 +1,20 @@
-import akka.actor.ActorSystem
-import com.improving.app.common.domain.{Contact, OrganizationId, TenantId, MemberId}
+import akka.grpc.GrpcClientSettings
+import com.improving.app.common.domain.{Contact, MemberId, OrganizationId, TenantId}
 import com.improving.app.member.domain.MemberStatus._
 import com.improving.app.member.domain.NotificationPreference.NOTIFICATION_PREFERENCE_EMAIL
 import org.scalatest.Inside.inside
 import com.improving.app.member.domain._
-
-import akka.grpc.GrpcClientSettings
-import com.dimafeng.testcontainers.{DockerComposeContainer, ExposedService}
-import com.dimafeng.testcontainers.scalatest.TestContainerForAll
+import com.improving.app.common.test.ServiceTestContainerSpec
 import com.improving.app.member.api.{MemberService, MemberServiceClient}
 import com.improving.app.member.domain.GetMemberInfo
 
-import java.io.File
-import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.flatspec._
-import org.scalatest.matchers.should.Matchers
-import org.scalatest.time.{Millis, Minutes, Span}
-import org.testcontainers.containers.wait.strategy.Wait
+class MemberServerSpec extends ServiceTestContainerSpec(8081, "member-service") {
 
-class MemberServerSpec extends AnyFlatSpec with TestContainerForAll with Matchers with ScalaFutures {
-  // Implicits for running and testing functions of the gRPC server
-  implicit override val patienceConfig: PatienceConfig =
-    PatienceConfig(timeout = Span(3, Minutes), interval = Span(10, Millis))
-  implicit protected val system: ActorSystem = ActorSystem("testActor")
-
-  // Definition of the container to use. This assumes the sbt command
-  // 'sbt docker:publishLocal' has been run such that
-  // 'docker image ls' shows "improving-app-tenant:latest" as a record
-  // Since the tenant-service uses cassandra for persistence, a docker compose file is used to also run the scylla db
-  // container
-  val exposedPort = 8081 // This exposed port should match the port on Helpers.scala
-  val serviceName = "member-service" // This should be the same name as the container in docker-compose.yml
+  private def getClient(containers: Containers): MemberService = {
+    val (host, port) = getContainerHostPort(containers)
+    val clientSettings: GrpcClientSettings = GrpcClientSettings.connectToServiceAt(host, port).withTls(false)
+    MemberServiceClient(clientSettings)
+  }
 
   val memberInfo = MemberSpec.createMemberInfo()
   var memberId: MemberId = null
@@ -53,28 +37,11 @@ class MemberServerSpec extends AnyFlatSpec with TestContainerForAll with Matcher
     }
   }
 
-  override val containerDef =
-    DockerComposeContainer.Def(
-      new File("./docker-compose.yml"),
-      tailChildContainers = true,
-      exposedServices = Seq(
-        ExposedService(serviceName, exposedPort, Wait.forLogMessage(".*gRPC server bound to 0.0.0.0:8081*.", 1))
-      )
-    )
-
-  private def getClient(containers: Containers): MemberService = {
-    val host = containers.container.getServiceHost(serviceName, exposedPort)
-    val port = containers.container.getServicePort(serviceName, exposedPort)
-
-    val clientSettings: GrpcClientSettings = GrpcClientSettings.connectToServiceAt(host, port).withTls(false)
-    MemberServiceClient(clientSettings)
-  }
-
   behavior of "MemberServer in a test container"
 
-  it should s"expose a port for $serviceName" in {
-    withContainers { a =>
-      assert(a.container.getServicePort(serviceName, exposedPort) > 0)
+  it should s"expose a port for member-service" in {
+    withContainers { containers =>
+      validateExposedPort(containers)
     }
   }
 

--- a/member/src/main/scala/com/improving/app/member/Main.scala
+++ b/member/src/main/scala/com/improving/app/member/Main.scala
@@ -1,47 +1,21 @@
 package com.improving.app.member
 
 import akka.actor.typed.ActorSystem
-import akka.actor.typed.scaladsl.Behaviors
-import akka.http.scaladsl.Http
 import akka.http.scaladsl.model.{HttpRequest, HttpResponse}
+import com.improving.app.common.service.ServiceMain
 import com.improving.app.member.api.{MemberServiceHandler, MemberServiceImpl}
-import com.typesafe.config.ConfigFactory
-import com.typesafe.scalalogging.StrictLogging
+import scala.concurrent.Future
 
-import scala.concurrent.duration.DurationInt
-import scala.concurrent.{ExecutionContext, Future}
-import scala.util.{Failure, Success}
+/**
+ * This is the running application for the Members project.
+ */
+object Main extends ServiceMain {
+  override val projectName = "improving-app-member"
+  override val port = 8081
 
-object Main extends App with StrictLogging {
-  val projectName = "improving-app-member"
-  val port = 8081
-
-  val conf = ConfigFactory
-    .load("application.conf")
-    .withFallback(ConfigFactory.defaultApplication())
-  implicit val system = ActorSystem[Nothing](Behaviors.empty, projectName, conf)
-
-  // ActorSystem threads will keep the app alive until `system.terminate()` is called
-
-  // Akka boot up code
-  implicit val ec: ExecutionContext = system.executionContext
-
-  // Create service handlers
-  val service: HttpRequest => Future[HttpResponse] =
-    MemberServiceHandler.withServerReflection(new MemberServiceImpl())
-
-  val bound: Future[Http.ServerBinding] = Http(system)
-    .newServerAt(interface = "0.0.0.0", port = port)
-    //      .enableHttps(serverHttpContext)
-    .bind(service)
-    .map(_.addToCoordinatedShutdown(hardTerminationDeadline = 30.seconds))
-
-  bound.onComplete {
-    case Success(binding) =>
-      val address = binding.localAddress
-      println(s"$projectName gRPC server bound to ${address.getHostString}:${address.getPort}")
-    case Failure(ex) =>
-      println(s"Failed to bind gRPC endpoint for $projectName, terminating system: ${ex.getMessage}")
-      system.terminate()
+  override def service(system: ActorSystem[Nothing]): HttpRequest => Future[HttpResponse] = {
+    MemberServiceHandler.withServerReflection(new MemberServiceImpl()(system))(system)
   }
+
+  run()
 }

--- a/project/Helpers.scala
+++ b/project/Helpers.scala
@@ -128,7 +128,14 @@ object C {
         Test / logBuffered := false,
         run / fork := false,
         Global / cancelable := false, // ctrl-c
-        libraryDependencies ++= Seq("org.scalatest" %% "scalatest" % V.scalatest % Test),
+        libraryDependencies ++= Seq(
+          "org.scalatest" %% "scalatest" % V.scalatest,
+          "com.dimafeng" %% "testcontainers-scala-scalatest" % V.testcontainersScalaVersion,
+          "com.dimafeng" %% "testcontainers-scala-cassandra" % V.testcontainersScalaVersion,
+          "com.typesafe.akka" %% "akka-actor-typed" % V.akka,
+          "com.typesafe.scala-logging" %% "scala-logging" % V.scalalogging,
+          "com.typesafe.akka" %% "akka-http-core" % V.akkaHttp
+        ),
       )
       .configure(scalapbCodeGen)
   }

--- a/tenant/src/main/scala/com/improving/app/tenant/Main.scala
+++ b/tenant/src/main/scala/com/improving/app/tenant/Main.scala
@@ -1,52 +1,19 @@
 package com.improving.app.tenant
 
 import akka.actor.typed.ActorSystem
-import akka.actor.typed.scaladsl.Behaviors
-import akka.http.scaladsl.Http
 import akka.http.scaladsl.model.{HttpRequest, HttpResponse}
+import com.improving.app.common.service.ServiceMain
 import com.improving.app.tenant.api.TenantServiceHandler
-import com.typesafe.config.ConfigFactory
-import com.typesafe.scalalogging.StrictLogging
-
-import scala.concurrent.duration.DurationInt
-import scala.concurrent.{ExecutionContext, Future}
-import scala.util.{Failure, Success}
+import scala.concurrent.Future
 
 /**
- * This is the running application for the Tenant project. This file represents the typical pattern for a gRPC server
- * and the parts that only vary across projects is the projectName, port, Actor to start off with, and the names of the
- * ServiceHandlers/ServiceImpl.
+ * This is the running application for the Tenant project.
  */
-object Main extends App with StrictLogging {
-  val projectName = "improving-app-tenant"
-  val port = 8080
+object Main extends ServiceMain {
+  override val projectName = "improving-app-tenant"
+  override val port = 8080
+  override def service(system: ActorSystem[Nothing]): HttpRequest => Future[HttpResponse] =
+    TenantServiceHandler.withServerReflection(new TenantServiceImpl(system))(system)
 
-  val conf = ConfigFactory
-    .load("application.conf")
-    .withFallback(ConfigFactory.defaultApplication())
-  implicit val system = ActorSystem[Nothing](Behaviors.empty, projectName, conf)
-
-  // ActorSystem threads will keep the app alive until `system.terminate()` is called
-
-  // Akka boot up code
-  implicit val ec: ExecutionContext = system.executionContext
-
-  // Create service handlers
-  val service: HttpRequest => Future[HttpResponse] =
-    TenantServiceHandler.withServerReflection(new TenantServiceImpl(system))
-
-  val bound: Future[Http.ServerBinding] = Http(system)
-    .newServerAt(interface = "0.0.0.0", port = port)
-    //      .enableHttps(serverHttpContext)
-    .bind(service)
-    .map(_.addToCoordinatedShutdown(hardTerminationDeadline = 30.seconds))
-
-  bound.onComplete {
-    case Success(binding) =>
-      val address = binding.localAddress
-      println(s"$projectName gRPC server bound to ${address.getHostString}:${address.getPort}")
-    case Failure(ex) =>
-      println(s"Failed to bind gRPC endpoint for $projectName, terminating system: ${ex.getMessage}")
-      system.terminate()
-  }
+  run()
 }


### PR DESCRIPTION
Primary Reviewer: @reid-spencer 
Backup Reviewer: @AlexWeinstein92 

### Issues:

- Present in the main files and server test files is some common code. We expect that this will be widely used, so a dedicated file with the common code should be consolidated. 

### Changes:

- Create ServiceMain for common Main code
- Create ServiceTestContainerSpec for common server test code
- Notice ServiceTestContainerSpec doesn't have GRPC code. Adding the GRPC plugin into the common subproject does not interact well with the library dependencies and the generated scala files from protobufs. For this reason, GRPC code is kept in the server spec files 
- Refactor main files
- Refactor server test files

### Testing:

- tested Member and Tenant spec files
- tested Member and Tenant service spec files