### PR TITLE
IA-144 Implement get organizations in tenant

### DIFF
--- a/tenant/src/main/protobuf/com/improving/app/tenant/api/improving-app-tenant-api.proto
+++ b/tenant/src/main/protobuf/com/improving/app/tenant/api/improving-app-tenant-api.proto
@@ -16,4 +16,6 @@ service TenantService {
   rpc ActivateTenant (domain.ActivateTenant) returns (domain.TenantActivated) {}
 
   rpc SuspendTenant (domain.SuspendTenant) returns (domain.TenantSuspended) {}
+
+  rpc GetOrganizations (domain.GetOrganizations) returns (domain.OrganizationData) {}
 }

--- a/tenant/src/main/protobuf/com/improving/app/tenant/api/improving-app-tenant-api.proto
+++ b/tenant/src/main/protobuf/com/improving/app/tenant/api/improving-app-tenant-api.proto
@@ -17,5 +17,5 @@ service TenantService {
 
   rpc SuspendTenant (domain.SuspendTenant) returns (domain.TenantSuspended) {}
 
-  rpc GetOrganizations (domain.GetOrganizations) returns (domain.OrganizationData) {}
+  rpc GetOrganizations (domain.GetOrganizations) returns (domain.TenantOrganizationData) {}
 }

--- a/tenant/src/main/protobuf/com/improving/app/tenant/domain/improving-app-tenant-domain.proto
+++ b/tenant/src/main/protobuf/com/improving/app/tenant/domain/improving-app-tenant-domain.proto
@@ -63,6 +63,16 @@ message InfoEdited {
   TenantInfo new_info = 4;
 }
 
+message GetOrganizations {
+  option (scalapb.message).extends = "com.improving.app.common.serialize.PBMsgSerializable";
+  com.improving.app.common.domain.TenantId tenant_id = 1;
+}
+
+message OrganizationData {
+  option (scalapb.message).extends = "com.improving.app.common.serialize.PBMsgSerializable";
+  TenantOrganizationList organizations = 1;
+}
+
 message TenantRequest {
   option (scalapb.message).extends = "com.improving.app.common.serialize.PBMsgSerializable";
   oneof sealed_value {
@@ -70,6 +80,7 @@ message TenantRequest {
     ActivateTenant activate_tenant_value = 2;
     SuspendTenant suspend_tenant_value = 3;
     EditInfo edit_info_value = 4;
+    GetOrganizations get_organization_value = 5;
   }
 }
 
@@ -80,5 +91,28 @@ message TenantEvent {
     TenantActivated tenant_activated_value = 2;
     TenantSuspended tenant_suspended_value = 3;
     InfoEdited info_edited_value = 4;
+  }
+}
+
+message TenantData {
+  oneof sealed_value {
+    OrganizationData organization_data_value = 1;
+  }
+}
+
+message TenantEventResponse {
+  option (scalapb.message).extends = "com.improving.app.common.serialize.PBMsgSerializable";
+  TenantEvent tenant_event = 1;
+}
+
+message TenantDataResponse {
+  TenantData tenant_data = 1;
+}
+
+message TenantResponse {
+  option (scalapb.message).extends = "com.improving.app.common.serialize.PBMsgSerializable";
+  oneof sealed_value {
+    TenantEventResponse tenant_event_value = 1;
+    TenantDataResponse tenant_data_value = 2;
   }
 }

--- a/tenant/src/main/protobuf/com/improving/app/tenant/domain/improving-app-tenant-domain.proto
+++ b/tenant/src/main/protobuf/com/improving/app/tenant/domain/improving-app-tenant-domain.proto
@@ -109,7 +109,7 @@ message TenantDataResponse {
   TenantData tenant_data = 1;
 }
 
-message TenantResponse {
+message TenantEnvelope {
   option (scalapb.message).extends = "com.improving.app.common.serialize.PBMsgSerializable";
   oneof sealed_value {
     TenantEventResponse tenant_event_value = 1;

--- a/tenant/src/main/protobuf/com/improving/app/tenant/domain/improving-app-tenant-domain.proto
+++ b/tenant/src/main/protobuf/com/improving/app/tenant/domain/improving-app-tenant-domain.proto
@@ -68,7 +68,7 @@ message GetOrganizations {
   com.improving.app.common.domain.TenantId tenant_id = 1;
 }
 
-message OrganizationData {
+message TenantOrganizationData {
   option (scalapb.message).extends = "com.improving.app.common.serialize.PBMsgSerializable";
   TenantOrganizationList organizations = 1;
 }
@@ -96,7 +96,7 @@ message TenantEvent {
 
 message TenantData {
   oneof sealed_value {
-    OrganizationData organization_data_value = 1;
+    TenantOrganizationData organization_data_value = 1;
   }
 }
 

--- a/tenant/src/main/resources/sample-requests.txt
+++ b/tenant/src/main/resources/sample-requests.txt
@@ -2,7 +2,7 @@
 grpcurl -plaintext localhost:8080 list
 
 -- Establish Tenant
-grpcurl -plaintext -d '{"tenant_id": {"id": "tenantId"}, "establishing_user": {"id": "establishingUser"}, "tenant_info": { "name": "Tenant Name", "primary_contact": {"first_name": "firstName", "last_name": "lastName", "email_address": "email@email.com", "phone": "111-111-1111", "user_name": "userName"}, "address": {"line1": "line1", "line2": "line2", "city": "city", "state_province": "stateProvince", "country": "country", "postal_code": {"ca_postal_code_message": "caPostalCode"}}, "organizations": {"value": [{"id": "org1"}, {"id": "org2"}]} }}' localhost:8080 com.improving.app.tenant.api.TenantService/EstablishTenant
+grpcurl -plaintext -d '{"tenant_id": {"id": "tenantId"}, "establishing_user": {"id": "establishingUser"}, "tenant_info": { "name": "Tenant Name", "primaryContact": {"first_name": "firstName", "last_name": "lastName", "email_address": "email@email.com", "phone": "111-111-1111", "user_name": "userName"}, "address": {"line1": "line1", "line2": "line2", "city": "city", "state_province": "stateProvince", "country": "country", "postal_code": {"ca_postal_code_message": "caPostalCode"}}, "organizations": {"value": [{"id": "org1"}, {"id": "org2"}]} }}' localhost:8080 com.improving.app.tenant.api.TenantService/EstablishTenant
 
 -- Activate Tenant
 grpcurl -plaintext -d '{"tenant_id": {"id": "tenantId"}, "activating_user": {"id": "activatingUser"}}' localhost:8080 com.improving.app.tenant.api.TenantService/ActivateTenant
@@ -11,5 +11,8 @@ grpcurl -plaintext -d '{"tenant_id": {"id": "tenantId"}, "activating_user": {"id
 grpcurl -plaintext -d '{"tenant_id": {"id": "tenantId"}, "suspending_user": {"id": "suspendingUser"}}' localhost:8080 com.improving.app.tenant.api.TenantService/SuspendTenant
 
 -- Edit Info
-grpcurl -plaintext -d '{"tenant_id": {"id": "tenantId"}, "updating_user": {"id": "updatingUser"}, "info_to_update": { "name": "Tenant Name", "primary_contact": {"first_name": "firstName", "last_name": "lastName", "email_address": "email@email.com", "phone": "111-111-1111", "user_name": "userName"}, "address": {"line1": "line1", "line2": "line2", "city": "city", "state_province": "stateProvince", "country": "country", "postal_code": {"ca_postal_code_message": "caPostalCode"}}, "organizations": {"value": [{"id": "org1"}, {"id": "org2"}]} }}' localhost:8080 com.improving.app.tenant.api.TenantService/EditInfo
+grpcurl -plaintext -d '{"tenant_id": {"id": "tenantId"}, "editing_user": {"id": "updatingUser"}, "info_to_update": { "name": "Tenant Name", "primaryContact": {"first_name": "firstName", "last_name": "lastName", "email_address": "email@email.com", "phone": "111-111-1111", "user_name": "userName"}, "address": {"line1": "line1", "line2": "line2", "city": "city", "state_province": "stateProvince", "country": "country", "postal_code": {"ca_postal_code_message": "caPostalCode"}}, "organizations": {"value": [{"id": "org1"}, {"id": "org2"}]} }}' localhost:8080 com.improving.app.tenant.api.TenantService/EditInfo
+
+-- Get Organizations
+grpcurl -plaintext -d '{"tenant_id": {"id": "tenantId"}}' localhost:8080 com.improving.app.tenant.api.TenantService/GetOrganizations
 

--- a/tenant/src/main/scala/com/improving/app/tenant/TenantServiceImpl.scala
+++ b/tenant/src/main/scala/com/improving/app/tenant/TenantServiceImpl.scala
@@ -75,7 +75,7 @@ class TenantServiceImpl(sys: ActorSystem[_]) extends TenantService {
     )
   }
 
-  override def getOrganizations(in: GetOrganizations): Future[OrganizationData] = {
+  override def getOrganizations(in: GetOrganizations): Future[TenantOrganizationData] = {
     val result = sharding.entityRefFor(Tenant.TypeKey, in.tenantId.get.id)
       .ask(ref => Tenant.TenantCommand(in, ref))
     result.transform(

--- a/tenant/src/main/scala/com/improving/app/tenant/TenantServiceImpl.scala
+++ b/tenant/src/main/scala/com/improving/app/tenant/TenantServiceImpl.scala
@@ -42,7 +42,7 @@ class TenantServiceImpl(sys: ActorSystem[_]) extends TenantService {
     val result = sharding.entityRefFor(Tenant.TypeKey, in.tenantId.get.id)
       .ask(ref => Tenant.TenantCommand(in, ref))
     result.transform(
-      result => result.getValue.asMessage.sealedValue.tenantEstablishedValue.get,
+      result => result.getValue.asMessage.getTenantEventValue.tenantEvent.asMessage.getTenantEstablishedValue,
       exception => exceptionHandler(exception)
     )
   }
@@ -52,7 +52,7 @@ class TenantServiceImpl(sys: ActorSystem[_]) extends TenantService {
       .ask(ref => Tenant.TenantCommand(in, ref))
 
     result.transform(
-      result => result.getValue.asMessage.sealedValue.infoEditedValue.get,
+      result => result.getValue.asMessage.getTenantEventValue.tenantEvent.asMessage.getInfoEditedValue,
       exception => exceptionHandler(exception)
     )
   }
@@ -61,7 +61,7 @@ class TenantServiceImpl(sys: ActorSystem[_]) extends TenantService {
     val result = sharding.entityRefFor(Tenant.TypeKey, in.tenantId.get.id)
       .ask(ref => Tenant.TenantCommand(in, ref))
     result.transform(
-      result => result.getValue.asMessage.sealedValue.tenantActivatedValue.get,
+      result => result.getValue.asMessage.getTenantEventValue.tenantEvent.asMessage.getTenantActivatedValue,
       exception => exceptionHandler(exception)
     )
   }
@@ -70,7 +70,16 @@ class TenantServiceImpl(sys: ActorSystem[_]) extends TenantService {
     val result = sharding.entityRefFor(Tenant.TypeKey, in.tenantId.get.id)
       .ask(ref => Tenant.TenantCommand(in, ref))
     result.transform(
-      result => result.getValue.asMessage.sealedValue.tenantSuspendedValue.get,
+      result => result.getValue.asMessage.getTenantEventValue.tenantEvent.asMessage.getTenantSuspendedValue,
+      exception => exceptionHandler(exception)
+    )
+  }
+
+  override def getOrganizations(in: GetOrganizations): Future[OrganizationData] = {
+    val result = sharding.entityRefFor(Tenant.TypeKey, in.tenantId.get.id)
+      .ask(ref => Tenant.TenantCommand(in, ref))
+    result.transform(
+      result => result.getValue.asMessage.getTenantDataValue.tenantData.asMessage.getOrganizationDataValue,
       exception => exceptionHandler(exception)
     )
   }

--- a/tenant/src/main/scala/com/improving/app/tenant/domain/Tenant.scala
+++ b/tenant/src/main/scala/com/improving/app/tenant/domain/Tenant.scala
@@ -233,7 +233,7 @@ object Tenant {
     if (validationResult.isDefined) {
       Left(validationResult.get)
     } else {
-      Right(TenantDataResponse(OrganizationData(
+      Right(TenantDataResponse(TenantOrganizationData(
         organizations = stateOpt.fold[Option[TenantOrganizationList]](Some(TenantOrganizationList(Seq.empty))) {
           _.info.organizations
         }

--- a/tenant/src/main/scala/com/improving/app/tenant/domain/Tenant.scala
+++ b/tenant/src/main/scala/com/improving/app/tenant/domain/Tenant.scala
@@ -223,12 +223,12 @@ object Tenant {
   }
 
   private def getOrganizations(
-                                getOrganizationsCommand: GetOrganizations,
+                                getOrganizationsQuery: GetOrganizations,
                                 stateOpt: Option[Tenant.EstablishedTenantState] = None
                               ): Either[Error, TenantResponse] = {
     val validationResult = applyAllValidators[GetOrganizations](Seq(
       c => required("tenant id", tenantIdValidator)(c.tenantId)
-    ))(getOrganizationsCommand)
+    ))(getOrganizationsQuery)
 
     if (validationResult.isDefined) {
       Left(validationResult.get)

--- a/tenant/src/test/scala/com/improving/app/tenant/TenantSpec.scala
+++ b/tenant/src/test/scala/com/improving/app/tenant/TenantSpec.scala
@@ -32,19 +32,19 @@ class TenantSpec
     with Matchers {
   override def afterAll(): Unit = testKit.shutdownTestKit()
 
-  def createTestVariables(): (String, ActorRef[TenantCommand], TestProbe[StatusReply[TenantResponse]]) = {
+  def createTestVariables(): (String, ActorRef[TenantCommand], TestProbe[StatusReply[TenantEnvelope]]) = {
     val tenantId = Random.nextString(31)
     val p = this.testKit.spawn(Tenant(PersistenceId.ofUniqueId(tenantId)))
-    val probe = this.testKit.createTestProbe[StatusReply[TenantResponse]]()
+    val probe = this.testKit.createTestProbe[StatusReply[TenantEnvelope]]()
     (tenantId, p, probe)
   }
 
   def establishTenant(
     tenantId: String,
     p: ActorRef[TenantCommand],
-    probe: TestProbe[StatusReply[TenantResponse]],
+    probe: TestProbe[StatusReply[TenantEnvelope]],
     tenantInfo: TenantInfo = baseTenantInfo
-  ): StatusReply[TenantResponse] = {
+  ): StatusReply[TenantEnvelope] = {
     p ! Tenant.TenantCommand(
       EstablishTenant(
         tenantId = Some(TenantId(tenantId)),


### PR DESCRIPTION
Primary Reviewer for GetOrganizations: @AlexWeinstein92 
Primary Reviewer for overall Tenant Code quality: @dag-yoppworks 
Primary Reviewer if available: @reid-spencer 

### Issue:

- GetOrganizations command is needed. There is no projection here
- Tenant has some unnecessary code (the sealed value stuff) for match blocks
- Existing code always persisted events when queries aren't actually events

### Changes:

- implement GetOrganizations
- refactored tenant responses to either be TenantEventResponses or TenantDataResponses
- cleaned up code

### Testing:
- manual testing
- ran ci testing