### PR TITLE
IA-169 Implement terminated handler in tenant

### DIFF
--- a/common-types/src/main/scala/com/improving/app/common/errors/Validation.scala
+++ b/common-types/src/main/scala/com/improving/app/common/errors/Validation.scala
@@ -16,7 +16,7 @@ object Validation {
   def required[T]: (String, Validator[T]) => Validator[Option[T]] = (fieldName, validator) => {
     opt =>
       if (opt.isEmpty) {
-        Some(ValidationError(fieldName + " is missing."))
+        Some(ValidationError("No associated " + fieldName))
       } else {
         validator(opt.get)
       }

--- a/organization/src/it/scala/OrganizationServerSpec.scala
+++ b/organization/src/it/scala/OrganizationServerSpec.scala
@@ -99,7 +99,7 @@ class OrganizationServerSpec extends ServiceTestContainerSpec(8082, "organizatio
     }
   }
 
-  it should "properly process ActivateOrganization" in {
+  it should "properly process ActivateOrganization" taggedAs(Retryable) in {
     withContainers { containers =>
       val client = getClient(containers)
 

--- a/organization/src/it/scala/OrganizationServerSpec.scala
+++ b/organization/src/it/scala/OrganizationServerSpec.scala
@@ -5,6 +5,7 @@ import com.improving.app.common.test.ServiceTestContainerSpec
 import com.improving.app.organization.api.{OrganizationService, OrganizationServiceClient}
 import com.improving.app.organization.domain._
 import io.grpc.Status
+import org.scalatest.tagobjects.Retryable
 
 import scala.concurrent.Future
 import scala.util.Random
@@ -24,7 +25,7 @@ class OrganizationServerSpec extends ServiceTestContainerSpec(8082, "organizatio
     }
   }
 
-  it should "gracefully handle bad requests that fail at service level" in {
+  it should "gracefully handle bad requests that fail at service level" taggedAs(Retryable) in {
     withContainers { containers =>
       val client = getClient(containers)
 

--- a/tenant/src/main/protobuf/com/improving/app/tenant/api/improving-app-tenant-api.proto
+++ b/tenant/src/main/protobuf/com/improving/app/tenant/api/improving-app-tenant-api.proto
@@ -18,4 +18,6 @@ service TenantService {
   rpc SuspendTenant (domain.SuspendTenant) returns (domain.TenantSuspended) {}
 
   rpc GetOrganizations (domain.GetOrganizations) returns (domain.TenantOrganizationData) {}
+
+  rpc TerminateTenant (domain.TerminateTenant) returns (domain.TenantTerminated) {}
 }

--- a/tenant/src/main/protobuf/com/improving/app/tenant/domain/improving-app-tenant-domain.proto
+++ b/tenant/src/main/protobuf/com/improving/app/tenant/domain/improving-app-tenant-domain.proto
@@ -63,6 +63,17 @@ message InfoEdited {
   TenantInfo new_info = 4;
 }
 
+message TerminateTenant {
+  com.improving.app.common.domain.TenantId tenant_id = 1;
+  com.improving.app.common.domain.MemberId terminating_user = 2;
+}
+
+message TenantTerminated {
+  option (scalapb.message).extends = "com.improving.app.common.serialize.PBMsgSerializable";
+  com.improving.app.common.domain.TenantId tenant_id = 1;
+  TenantMetaInfo meta_info = 2;
+}
+
 message GetOrganizations {
   option (scalapb.message).extends = "com.improving.app.common.serialize.PBMsgSerializable";
   com.improving.app.common.domain.TenantId tenant_id = 1;
@@ -81,6 +92,7 @@ message TenantRequest {
     SuspendTenant suspend_tenant_value = 3;
     EditInfo edit_info_value = 4;
     GetOrganizations get_organization_value = 5;
+    TerminateTenant terminate_tenant_value = 6;
   }
 }
 
@@ -91,6 +103,7 @@ message TenantEvent {
     TenantActivated tenant_activated_value = 2;
     TenantSuspended tenant_suspended_value = 3;
     InfoEdited info_edited_value = 4;
+    TenantTerminated tenant_terminated_value = 5;
   }
 }
 

--- a/tenant/src/main/resources/sample-requests.txt
+++ b/tenant/src/main/resources/sample-requests.txt
@@ -16,3 +16,7 @@ grpcurl -plaintext -d '{"tenant_id": {"id": "tenantId"}, "editing_user": {"id": 
 -- Get Organizations
 grpcurl -plaintext -d '{"tenant_id": {"id": "tenantId"}}' localhost:8080 com.improving.app.tenant.api.TenantService/GetOrganizations
 
+-- Terminate Tenant
+grpcurl -plaintext -d '{"tenant_id": {"id": "tenantId"}, "terminating_user": {"id": "terminatingUser"}}' localhost:8080 com.improving.app.tenant.api.TenantService/TerminateTenant
+
+


### PR DESCRIPTION
Primary Reviewer: @AlexWeinstein92 
Reviewer for overall code quality: @dag-yoppworks 

### Issues:

- terminate handler was not present in tenant for some reason

### Changes:

- created protobufs for terminate handler
- created business logic for terminate handler
- created tests on unit test and integration tests
- added tests for validation on the terminate tenant tests

### Testing:
- CI tests
- manual testing